### PR TITLE
Modify upsert to return an entity if a key has been found

### DIFF
--- a/src/Helpers/QueryBuilderHelper.php
+++ b/src/Helpers/QueryBuilderHelper.php
@@ -178,11 +178,7 @@ trait QueryBuilderHelper
         endforeach;
 
         if($key instanceof \Google\Cloud\Datastore\Key):
-            $entity = $this->getClient()->lookup($key);
-
-            if($entity == null):
-                $entity = $this->getClient()->entity($key, $values, $options);
-            endif;
+            $entity = $this->getClient()->lookup($key) ?? $this->getClient()->entity($key, $values, $options);
 
             foreach($values as $key=>$value):
                 $entity->$key = $value;

--- a/src/Helpers/QueryBuilderHelper.php
+++ b/src/Helpers/QueryBuilderHelper.php
@@ -179,6 +179,11 @@ trait QueryBuilderHelper
 
         if($key instanceof \Google\Cloud\Datastore\Key):
             $entity = $this->getClient()->lookup($key);
+
+            if($entity == null):
+                $entity = $this->getClient()->entity($key, $values, $options);
+            endif;
+
             foreach($values as $key=>$value):
                 $entity->$key = $value;
             endforeach;


### PR DESCRIPTION
This is a very simple change where it will search the values of `$wheres` in `Appsero\LaravelDatastore\Query\Builder` if a key of instance type `\Google\Cloud\Datastore\Key` is found, we will then return the Entity from Google Datastore then apply the mutations via values.

This also allows for Laravel Models to be updated via `$model->save()`;

E.g.

```php

   $myModel = MyModel::where("abc", $value)->first();
   $myModel->def = "newValue";
   $myModel->save();

```