### PR TITLE
Support for laravel 9 & 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,48 @@
 {
-    "name": "appsero/laravel-datastore",
-    "version": "0.0.4",
-    "description": "A package for using google datastore as a database driver.",
-    "type": "package",
-    "license": "MIT",
-    "keywords": ["laravel datastore", "datastore", "google datastore"],
-    "homepage": "https://github.com/appsero/laravel-datastore",
-    "authors": [
-        {
-            "name": "Appsero",
-            "email": "help@appsero.com"
-        }
-    ],
-    "require": {
-        "php": "^7.2|^8.0",
-        "ext-json": "*",
-        "illuminate/support": "^6|^7|^8|^9.0|^10.0",
-        "illuminate/pagination": "^6|^7|^8|^9.0|^10.0",
-        "illuminate/database": "^6|^7|^8|^9.0|^10.0",
-        "illuminate/http": "^6|^7|^8|^9.0|^10.0",
-        "google/cloud-datastore": "^1.12"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Appsero\\LaravelDatastore\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Appsero\\LaravelDatastore\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Appsero\\LaravelDatastore\\DatastoreServiceProvider"
-            ]
-        }
+  "name": "appsero/laravel-datastore",
+  "version": "0.0.4",
+  "description": "A package for using google datastore as a database driver.",
+  "type": "package",
+  "license": "MIT",
+  "keywords": [
+    "laravel datastore",
+    "datastore",
+    "google datastore"
+  ],
+  "homepage": "https://github.com/appsero/laravel-datastore",
+  "authors": [
+    {
+      "name": "Appsero",
+      "email": "help@appsero.com"
     }
+  ],
+  "require": {
+    "php": "^7.2|^8.0",
+    "ext-json": "*",
+    "illuminate/support": "^6|^7|^8|^9.0|^10.0",
+    "illuminate/pagination": "^6|^7|^8|^9.0|^10.0",
+    "illuminate/database": "^6|^7|^8|^9.0|^10.0",
+    "illuminate/http": "^6|^7|^8|^9.0|^10.0",
+    "google/cloud-datastore": "1.12"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Appsero\\LaravelDatastore\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Appsero\\LaravelDatastore\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Appsero\\LaravelDatastore\\DatastoreServiceProvider"
+      ]
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
-        "illuminate/support": "^6|^7|^8",
-        "illuminate/pagination": "^6|^7|^8",
-        "illuminate/database": "^6|^7|^8",
-        "illuminate/http": "^6|^7|^8",
+        "illuminate/support": "^6|^7|^8|^9.0|^10.0",
+        "illuminate/pagination": "^6|^7|^8|^9.0|^10.0",
+        "illuminate/database": "^6|^7|^8|^9.0|^10.0",
+        "illuminate/http": "^6|^7|^8|^9.0|^10.0",
         "google/cloud-datastore": "^1.12"
     },
     "require-dev": {


### PR DESCRIPTION
1. Upgrade laravel illuminate/support,  illuminate/pagination, illuminate/database, illuminate/http to version 9 $ 10
2. Downgrade or fixed google/cloud-datastore version to 1.12