### PR TITLE
Update the upsert method to match the array passed from Laravel Builder

### DIFF
--- a/src/Helpers/QueryBuilderHelper.php
+++ b/src/Helpers/QueryBuilderHelper.php
@@ -158,13 +158,13 @@ trait QueryBuilderHelper
             throw new \LogicException('No kind/table specified');
         }
 
-        if (empty($values)) {
+        if (empty($values[0])) {
             return true;
         }
 
         $key = $key ? $this->getClient()->key($this->from, $key) : $this->getClient()->key($this->from);
 
-        $entity = $this->getClient()->entity($key, $values, $options);
+        $entity = $this->getClient()->entity($key, $values[0], $options);
 
         return $this->getClient()->upsert($entity);
     }


### PR DESCRIPTION
Upsert has been added to Laravel since v8.x. A Laravel upsert expects 2 parameters to be passed, which are usually arrays

[Laravel Upsert Documentation](https://laravel.com/docs/8.x/eloquent#upserts)
```
Flight::upsert([
    ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => 99],
    ['departure' => 'Chicago', 'destination' => 'New York', 'price' => 150]
], ['departure', 'destination'], ['price']);
```
If the array of values is not nested in an array then the builder will automatically wrap the value in an array

[Laravel Upsert Method](https://github.com/laravel/framework/blob/aacd0669c122f462656a8f9fb48a24e5f8c3f6fb/src/Illuminate/Database/Eloquent/Builder.php#L1076)
```
if (! is_array(reset($values))) {
            $values = [$values];
        }
```

This means that the value passed to the datastore SDK is invalid and will fail, This fix will allow the upsert to behave as expected.