### PR TITLE
REST and Datastore Emulator Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Laravel Datastore](https://banners.beyondco.de/Laravel%20Datastore.png?theme=light&packageManager=composer+require&packageName=Appsero%2Flaravel-datastore&pattern=architect&style=style_1&description=Package+for+using+google+datastore+as+a+database+driver+in+laravel.&md=1&showWatermark=0&fontSize=100px&images=database)
+
 # Datastore Driver for Laravel
 
 ![Latest Stable Version](https://poser.pugx.org/appsero/laravel-datastore/v)

--- a/README.md
+++ b/README.md
@@ -48,10 +48,13 @@ You need to add `datastore` connection in `config/database.php` file.
         'driver' => 'datastore',
         'key_file_path' => env('GOOGLE_APPLICATION_CREDENTIALS', 'gcloud-credentials.json'),
         'prefix' => env('DATASTORE_PREFIX', null),
+        'transport' => 'grpc', // optional, defaults to grpc
     ],
     ...
 ],
 ```
+
+Please note: you can point to a local Datastore emulator by setting the `DATASTORE_EMULATOR_HOST` environment variable. In that case passing in a key file is not required.
 
 ### Access using Eloquent Model
 

--- a/src/DatastoreConnection.php
+++ b/src/DatastoreConnection.php
@@ -63,7 +63,7 @@ class DatastoreConnection extends Connection
     public function makeClient($config): DatastoreConnection
     {
         $client = new DatastoreClient([
-            'keyFilePath' => $config['key_file_path'] ?? base_path('gcloud-credentials.json'),
+            'keyFilePath' => $config['key_file_path'] ?? null,
             'transport' => $config['transport'] ?? 'grpc',
         ]);
 

--- a/src/DatastoreConnection.php
+++ b/src/DatastoreConnection.php
@@ -64,6 +64,7 @@ class DatastoreConnection extends Connection
     {
         $client = new DatastoreClient([
             'keyFilePath' => $config['key_file_path'] ?? base_path('gcloud-credentials.json'),
+            'transport' => $config['transport'] ?? 'grpc',
         ]);
 
         return $this->setClient($client);


### PR DESCRIPTION
- Use `transport` if it's passed in so `rest` can be selected.
- Make `key_file_path` optional. This way if the `DATASTORE_EMULATOR_HOST` env var is provided we can use the  local emulator without having a valid credentials json file.